### PR TITLE
fix latest build dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc='An easy to use, but flexible, composited Window Manager'
 arch=($CARCH)
 url='https://kde.org/plasma-desktop/'
 license=(LGPL)
-depends=(kscreenlocker-git xcb-util-cursor plasma-framework-git kcmutils-git kwayland-server-git breeze-git qt5-sensors qt5-script pipewire libqaccessibilityclient-git libdrm lcms2)
+depends=(kscreenlocker-git xcb-util-cursor plasma-framework-git kcmutils-git kwayland-server-git breeze-git qt5-sensors qt5-script pipewire libqaccessibilityclient-git libdrm lcms2 wayland-protocols-git)
 makedepends=(git extra-cmake-modules-git qt5-tools kdoctools-git krunner-git xorg-xwayland python)
 optdepends=('qt5-virtualkeyboard: virtual keyboard support for kwin-wayland'
             'maliit-keyboard: virtual keyboard support for kwin-wayland')


### PR DESCRIPTION
Latest build fails without wayland-protocols >= 1.25 dependency.

Tested manually and builds properly